### PR TITLE
ci: run on ubuntu-slim instead of ubuntu-latest

### DIFF
--- a/.github/workflows/sync_termux_com.yml
+++ b/.github/workflows/sync_termux_com.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   sync-termux-com:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu-slim has just 1 vCPU instead of 4 vCPU for ubuntu-latest. Runners
are limited to 15 minutes. We are just syncing two git repos, so this
should be fine

ubuntu-slim was available since 28 October 2025: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

Should reduce our CI usage effectively by atleast some amount (less
compute wasted)
